### PR TITLE
Feat: Add useActionState showcase page and navigation link

### DIFF
--- a/src/react/components/NavBar.tsx
+++ b/src/react/components/NavBar.tsx
@@ -13,6 +13,7 @@ function NavBar() {
       <ul>
         {link("/", "Home")}
         {link("/items", "Items")}
+        {link("/use-action-state-showcase", "Showcase")}
       </ul>
     </nav>
   );

--- a/src/react/pages/UseActionStateShowcase.tsx
+++ b/src/react/pages/UseActionStateShowcase.tsx
@@ -1,0 +1,46 @@
+import { useActionState } from 'react';
+
+// This is an async function that simulates submitting data to a server.
+// It takes the previous state and the form data as arguments.
+async function submitItem(previousState: string | null, formData: FormData) {
+  const itemName = formData.get('itemName') as string;
+
+  // Simulate a 1-second network delay
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  if (itemName.trim().length < 3) {
+    return 'Le nom de l\'article doit contenir au moins 3 caractères.';
+  }
+
+  // On success, return a success message.
+  return `"${itemName}" a été ajouté avec succès !`;
+}
+
+// This is our React component.
+export default function UseActionStateShowcase() {
+  // Here we use the useActionState hook.
+  const [state, formAction, isPending] = useActionState(submitItem, null);
+
+  return (
+    <article style={{ maxWidth: '600px', margin: '2rem auto' }}>
+      <header>
+        <h2>Showcase du Hook `useActionState`</h2>
+        <p>Ce formulaire montre comment gérer les états "pending", "success" et "error" d'une action de formulaire.</p>
+      </header>
+
+      <form action={formAction}>
+        <label htmlFor="itemName">
+          Nom de l'article
+          <input type="text" id="itemName" name="itemName" required />
+        </label>
+
+        <button type="submit" aria-disabled={isPending}>
+          {isPending ? 'Envoi en cours...' : 'Envoyer'}
+        </button>
+      </form>
+
+      {/* Display the success or error message from the state */}
+      {state && <p><strong>Statut :</strong> {state}</p>}
+    </article>
+  );
+}

--- a/src/react/routes.tsx
+++ b/src/react/routes.tsx
@@ -9,6 +9,7 @@ import ItemCreate from "./pages/ItemCreate";
 import ItemEdit from "./pages/ItemEdit";
 import ItemList from "./pages/ItemList";
 import ItemShow from "./pages/ItemShow";
+import UseActionStateShowcase from './pages/UseActionStateShowcase';
 
 import "./index.css";
 
@@ -24,6 +25,10 @@ export default [
       {
         index: true,
         element: <Home />,
+      },
+      {
+        path: "/use-action-state-showcase",
+        element: <UseActionStateShowcase />,
       },
       {
         path: "/items",


### PR DESCRIPTION
This pull request adds a navigation link to the `useActionState` showcase page, making it accessible from the main UI.

This completes the work started in issue #6 by not only creating the showcase but also integrating it into the site navigation.

### Changes included:
* Adds the `useActionState` showcase component and its corresponding route.
* Adds a "Showcase" link to the main navigation bar in `NavBar.tsx`.