### PR TITLE
Feat: Added `make:clone` command to clone modules/files 

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -126,6 +126,25 @@ To get started, refer to the following pages:
 | `docker compose run --build --rm server npm run test` | Runs tests |
 | `npm run biome:check` | Checks code quality with Biome (executed on pre-commit) |
 | `npm run types:check` | Checks type consistency with TypeScript (executed on pre-commit) |
+| `npm run make:clone <path to existing module> <path for new module>  <OldName> <NewName>` | Clone a module or file, renaming identifiers automatically |
+
+### Example: Clone Command 
+#### Cloning a Single File
+
+To clone a single file `itemActions.ts` into a new file `itemActionsCloned.ts`:
+
+```bash
+npm run make:clone src/express/modules/item/itemActions.ts src/express/modules/item/itemActionsCloned.ts itemActions clonedItemActions
+```
+
+#### Cloning a Whole Module
+
+To clone the entire `item` module folder into a new folder `itemCloned`:
+
+```bash
+npm run make:clone src/express/modules/item src/express/modules/itemCloned Item ItemCloned
+```
+
 
 ### REST cheatsheet
 

--- a/README.md
+++ b/README.md
@@ -117,15 +117,34 @@ Pour démarrer, référez-vous aux pages :
 
 ### Commandes de base
 
-| Commande                                                          | Description                                                                 |
-|-------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| `docker compose up --build`                                       | Build et démarre les services (ajouter `-d` pour démarrer en mode détaché)  |
-| `docker compose -f compose.prod.yaml up --build -d`               | Build et démarre en production                                              |
-| `docker compose logs -t`                                          | Affiche les logs avec les timestamps                                        |
-| `docker compose run --build --rm server npm run database:sync`    | Synchronise le contenu de la base de données avec `src/database/schema.sql` |
-| `docker compose run --build --rm server npm run test`             | Exécute les tests                                                           |
-| `npm run biome:check`                                             | Contrôle la qualité du code avec Biome (exécuté en pre-commit)              |
-| `npm run types:check`                                             | Contrôle la cohérence des types avec TypeScript (exécuté en pre-commit)     |
+| Commande                                                                                            | Description                                                                  |
+|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| `docker compose up --build`                                                                         | Build et démarre les services (ajouter `-d` pour démarrer en mode détaché)   |
+| `docker compose -f compose.prod.yaml up --build -d`                                                 | Build et démarre en production                                               |
+| `docker compose logs -t`                                                                            | Affiche les logs avec les timestamps                                         |
+| `docker compose run --build --rm server npm run database:sync`                                      | Synchronise le contenu de la base de données avec `src/database/schema.sql`  |
+| `docker compose run --build --rm server npm run test`                                               | Exécute les tests                                                            |
+| `npm run biome:check`                                                                               | Contrôle la qualité du code avec Biome (exécuté en pre-commit)               |
+| `npm run types:check`                                                                               | Contrôle la cohérence des types avec TypeScript (exécuté en pre-commit)      |
+| `npm run make:clone <chemin vers module existant> <chemin pour nouveau module> <OldName> <NewName>` | Clone un module ou un fichier, en renommant automatiquement les identifiants |
+
+### Exemple : Commande Clone
+
+#### Clonage d’un seul fichier
+
+Pour cloner un fichier **`itemActions.ts`** en un nouveau fichier **`itemActionsCloned.ts`** :
+
+```bash
+npm run make:clone src/express/modules/item/itemActions.ts src/express/modules/item/itemActionsCloned.ts itemActions clonedItemActions
+```
+
+#### Clonage d’un module entier
+Pour cloner tout le dossier du module item en un nouveau dossier itemCloned :
+
+```bash
+npm run make:clone src/express/modules/item src/express/modules/itemCloned Item ItemCloned
+```
+
 
 ### REST cheatsheet
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,17 @@
         "@types/compression": "^1.8.1",
         "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.3",
+        "@types/fs-extra": "^11.0.4",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@types/supertest": "^6.0.3",
         "@vitejs/plugin-react": "^5.0.4",
         "@vitest/coverage-v8": "^3.2.4",
+        "fs-extra": "^11.3.2",
         "jsdom": "^27.0.0",
         "supertest": "^7.1.4",
+        "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
         "vite": "^7.1.9",
@@ -572,6 +575,28 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1645,6 +1670,30 @@
         }
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1796,12 +1845,31 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -2118,6 +2186,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2151,6 +2243,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argon2": {
       "version": "0.44.0",
@@ -2575,6 +2673,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -2738,6 +2842,15 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3164,6 +3277,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3289,6 +3416,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3627,6 +3760,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -3823,6 +3968,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5045,6 +5196,49 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsx": {
       "version": "4.20.6",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
@@ -5100,6 +5294,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5139,6 +5342,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5564,6 +5773,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/zod": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev": "tsx --env-file=.env server",
     "start": "tsx --env-file=.env server",
     "test": "vitest run --coverage",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsc --noEmit",
+    "make:clone": "node --loader ts-node/esm src/scripts/make-clone.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.5",
@@ -22,14 +23,17 @@
     "@types/compression": "^1.8.1",
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.3",
+    "@types/fs-extra": "^11.0.4",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@types/supertest": "^6.0.3",
     "@vitejs/plugin-react": "^5.0.4",
     "@vitest/coverage-v8": "^3.2.4",
+    "fs-extra": "^11.3.2",
     "jsdom": "^27.0.0",
     "supertest": "^7.1.4",
+    "ts-node": "^10.9.2",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vite": "^7.1.9",

--- a/src/scripts/make-clone.ts
+++ b/src/scripts/make-clone.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env ts-node
+import fs from "fs-extra";
+import path from "path";
+
+/**
+ * Recursively walks through a directory,
+ * renames files and replaces content.
+ */
+async function walkAndReplace(
+  dir: string,
+  oldName: string,
+  newName: string
+): Promise<void> {
+  const files = await fs.readdir(dir);
+
+  for (const file of files) {
+    let fullPath = path.join(dir, file);
+    const stat = await fs.stat(fullPath);
+
+    if (stat.isDirectory()) {
+      await walkAndReplace(fullPath, oldName, newName);
+    } else {
+      // ✅ Rename file if filename contains oldName
+      let newFilePath = fullPath.replace(oldName, newName);
+      if (newFilePath !== fullPath) {
+        await fs.move(fullPath, newFilePath, { overwrite: true });
+        fullPath = newFilePath;
+      }
+
+      // ✅ Replace inside file
+      let content = await fs.readFile(fullPath, "utf8");
+      const regex = new RegExp(`\\b${oldName}\\b`, "g");
+      content = content.replace(regex, newName);
+      await fs.writeFile(fullPath, content, "utf8");
+    }
+  }
+}
+
+async function main() {
+  const [, , src, dest, oldName, newName] = process.argv;
+
+  if (!src || !dest || !oldName || !newName) {
+    console.error(
+      "Usage: npm run make:clone <src> <dest> <OldName> <NewName>"
+    );
+    process.exit(1);
+  }
+
+  const srcPath = path.resolve(src);
+  const destPath = path.resolve(dest);
+
+  if (!(await fs.pathExists(srcPath))) {
+    console.error(`❌ Source path does not exist: ${srcPath}`);
+    process.exit(1);
+  }
+
+  const stat = await fs.stat(srcPath);
+
+  if (stat.isFile()) {
+    // ✅ Handle single file cloning
+    await fs.copy(srcPath, destPath);
+    let content = await fs.readFile(destPath, "utf8");
+
+    // Replace identifiers
+    const regex = new RegExp(`\\b${oldName}\\b`, "g");
+    content = content.replace(regex, newName);
+
+    await fs.writeFile(destPath, content, "utf8");
+    console.log(`✅ Cloned file ${srcPath} → ${destPath}`);
+  } else if (stat.isDirectory()) {
+    // ✅ Handle folder cloning
+    await fs.copy(srcPath, destPath);
+    await walkAndReplace(destPath, oldName, newName);
+    console.log(`✅ Cloned folder ${srcPath} → ${destPath}`);
+  } else {
+    console.error("❌ Source is neither a file nor a directory.");
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Summary

This PR introduces a new developer feature: the `make:clone` command.

The command enables users to clone a module or a single file in the StartER project, automatically renaming identifiers to prevent manual renaming and errors.  
It supports both single-file cloning and entire module cloning, making development faster and more consistent.

---

### Feature Details

- **Command:** `npm run make:clone <source> <destination> <OldName> <NewName>`  
- Automatically updates all occurrences of `<OldName>` in file contents and filenames to `<NewName>`.
- Supports:
  - **Single file cloning**
  - **Full module cloning** (recursive)

---

### Examples

**1️⃣ Cloning a Single File**

```bash
npm run make:clone src/express/modules/item/itemActions.ts src/express/modules/item/itemActionsCloned.ts itemActions clonedItemActions
```
- Copies `itemActions.ts` → `itemActionsCloned.ts`
- Replaces all occurrences of `itemActions` inside the file with `clonedItemActions`

**2️⃣ Cloning a Whole Module**
```bash
npm run make:clone src/express/modules/item src/express/modules/itemCloned Item ItemCloned
```
- Copies the folder `item/` → `itemCloned/`
- Renames all files and updates all identifiers from `Item` → `ItemCloned` recursively inside the module

This PR closes issue #8 