### PR TITLE
Feat/useformstatus showcase

### DIFF
--- a/src/react/components/NavBar.tsx
+++ b/src/react/components/NavBar.tsx
@@ -13,6 +13,7 @@ function NavBar() {
       <ul>
         {link("/", "Home")}
         {link("/items", "Items")}
+        {link("/use-action-state-showcase", "Showcase")}
       </ul>
     </nav>
   );

--- a/src/react/components/NavBar.tsx
+++ b/src/react/components/NavBar.tsx
@@ -14,6 +14,7 @@ function NavBar() {
         {link("/", "Home")}
         {link("/items", "Items")}
         {link("/use-action-state-showcase", "Showcase")}
+        {link("/use-form-status-showcase", "useFormStatus")}
       </ul>
     </nav>
   );

--- a/src/react/pages/UseActionStateShowcase.tsx
+++ b/src/react/pages/UseActionStateShowcase.tsx
@@ -1,0 +1,46 @@
+import { useActionState } from 'react';
+
+// This is an async function that simulates submitting data to a server.
+// It takes the previous state and the form data as arguments.
+async function submitItem(previousState: string | null, formData: FormData) {
+  const itemName = formData.get('itemName') as string;
+
+  // Simulate a 1-second network delay
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  if (itemName.trim().length < 3) {
+    return 'Le nom de l\'article doit contenir au moins 3 caractères.';
+  }
+
+  // On success, return a success message.
+  return `"${itemName}" a été ajouté avec succès !`;
+}
+
+// This is our React component.
+export default function UseActionStateShowcase() {
+  // Here we use the useActionState hook.
+  const [state, formAction, isPending] = useActionState(submitItem, null);
+
+  return (
+    <article style={{ maxWidth: '600px', margin: '2rem auto' }}>
+      <header>
+        <h2>Showcase du Hook `useActionState`</h2>
+        <p>Ce formulaire montre comment gérer les états "pending", "success" et "error" d'une action de formulaire.</p>
+      </header>
+
+      <form action={formAction}>
+        <label htmlFor="itemName">
+          Nom de l'article
+          <input type="text" id="itemName" name="itemName" required />
+        </label>
+
+        <button type="submit" aria-disabled={isPending}>
+          {isPending ? 'Envoi en cours...' : 'Envoyer'}
+        </button>
+      </form>
+
+      {/* Display the success or error message from the state */}
+      {state && <p><strong>Statut :</strong> {state}</p>}
+    </article>
+  );
+}

--- a/src/react/pages/UseFormStatusShowcase.tsx
+++ b/src/react/pages/UseFormStatusShowcase.tsx
@@ -1,0 +1,53 @@
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+
+// This is the action function that simulates a server request.
+async function submitForm(previousState: string | null, formData: FormData) {
+  const name = formData.get('name') as string;
+
+  // Simulate a 2-second network delay
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Return a success message
+  return `Merci, ${name} ! Votre message a été reçu.`;
+}
+
+// A separate component for the submit button.
+// `useFormStatus` must be used in a component that is a child of the <form>.
+function SubmitButton() {
+  // The `useFormStatus` hook gives us the status of the parent form.
+  const { pending } = useFormStatus();
+
+  return (
+    <button type="submit" aria-disabled={pending}>
+      {pending ? 'Envoi en cours...' : 'Envoyer'}
+    </button>
+  );
+}
+
+// This is the main page component.
+export default function UseFormStatusShowcase() {
+  const [state, formAction] = useActionState(submitForm, null);
+
+  return (
+    <article style={{ maxWidth: '600px', margin: '2rem auto' }}>
+      <header>
+        <h2>Showcase du Hook `useFormStatus`</h2>
+        <p>Ce formulaire utilise `useFormStatus` pour désactiver le bouton d'envoi pendant la soumission.</p>
+      </header>
+
+      <form action={formAction}>
+        <label htmlFor="name">
+          Votre nom
+          <input type="text" id="name" name="name" required />
+        </label>
+        
+        {/* The SubmitButton component is used here */}
+        <SubmitButton />
+      </form>
+
+      {/* Display the success message from the state */}
+      {state && <p><strong>Statut :</strong> {state}</p>}
+    </article>
+  );
+}

--- a/src/react/routes.tsx
+++ b/src/react/routes.tsx
@@ -9,6 +9,7 @@ import ItemCreate from "./pages/ItemCreate";
 import ItemEdit from "./pages/ItemEdit";
 import ItemList from "./pages/ItemList";
 import ItemShow from "./pages/ItemShow";
+import UseActionStateShowcase from './pages/UseActionStateShowcase';
 
 import "./index.css";
 
@@ -24,6 +25,10 @@ export default [
       {
         index: true,
         element: <Home />,
+      },
+      {
+        path: "/use-action-state-showcase",
+        element: <UseActionStateShowcase />,
       },
       {
         path: "/items",

--- a/src/react/routes.tsx
+++ b/src/react/routes.tsx
@@ -10,6 +10,7 @@ import ItemEdit from "./pages/ItemEdit";
 import ItemList from "./pages/ItemList";
 import ItemShow from "./pages/ItemShow";
 import UseActionStateShowcase from './pages/UseActionStateShowcase';
+import UseFormStatusShowcase from './pages/UseFormStatusShowcase';
 
 import "./index.css";
 
@@ -30,6 +31,10 @@ export default [
         path: "/use-action-state-showcase",
         element: <UseActionStateShowcase />,
       },
+      {
+        path: "/use-form-status-showcase",
+        element: <UseFormStatusShowcase />,
+    },
       {
         path: "/items",
         element: (


### PR DESCRIPTION
This pull request adds a navigation link to the `useActionState` showcase page, making it accessible from the main UI.

This completes the work started in issue #6 by not only creating the showcase but also integrating it into the site navigation.

### Changes included:
* Adds the `useActionState` showcase component and its corresponding route.
* Adds a "Showcase" link to the main navigation bar in `NavBar.tsx`.