### PR TITLE
feat: update tsconfig to ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
Updated to this,
1. target from ES2020 → ES2022
2. lib from ["ES2020", "DOM", "DOM.Iterable"] → ["ES2022", "DOM", "DOM.Iterable"]